### PR TITLE
Update to v1.22

### DIFF
--- a/petai.csproj
+++ b/petai.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/resources/assets/petai/patches/entities/player.json
+++ b/resources/assets/petai/patches/entities/player.json
@@ -1,5 +1,6 @@
 [
     {
+      "side": "server",
       "op": "add",
       "path": "/server/behaviors/-",
       "value": {
@@ -8,12 +9,13 @@
       "file": "game:entities/humanoid/player.json"
     },
     {
+      "side": "server",
       "op": "add",
       "path": "/client/animations/-",
       "value": {
         "code": "rideidle",
-				"animation": "rideidle", 
-				"blendMode": "Average" 
+				"animation": "rideidle",
+				"blendMode": "Average"
       },
       "file": "game:entities/humanoid/player.json"
     }

--- a/resources/assets/petai/patches/itemtypes/bone.json
+++ b/resources/assets/petai/patches/itemtypes/bone.json
@@ -1,5 +1,6 @@
 [
     {
+    "side": "server",
     "op": "replace",
     "path": "/tpHandTransform",
     "value": {

--- a/resources/assets/petai/patches/itemtypes/bushmeat.json
+++ b/resources/assets/petai/patches/itemtypes/bushmeat.json
@@ -1,5 +1,6 @@
 [
     {
+    "side": "server",
     "op": "replace",
     "path": "/tpHandTransform",
     "value": {

--- a/resources/assets/petai/patches/itemtypes/poultry.json
+++ b/resources/assets/petai/patches/itemtypes/poultry.json
@@ -1,5 +1,6 @@
 [
     {
+    "side": "server",
     "op": "replace",
     "path": "/tpHandTransform",
     "value": {

--- a/resources/assets/petai/patches/itemtypes/readmeat.json
+++ b/resources/assets/petai/patches/itemtypes/readmeat.json
@@ -1,5 +1,6 @@
 [
     {
+    "side": "server",
     "op": "replace",
     "path": "/tpHandTransformByType/*",
     "value": {

--- a/resources/assets/petai/patches/itemtypes/vegetable.json
+++ b/resources/assets/petai/patches/itemtypes/vegetable.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "add",
         "path": "/behaviors",
         "value": [

--- a/resources/assets/petai/patches/medieval-fashion/bushmeat.json
+++ b/resources/assets/petai/patches/medieval-fashion/bushmeat.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "add",
         "path": "/behaviors",
         "value": [

--- a/resources/assets/petai/patches/medieval-fashion/poultry.json
+++ b/resources/assets/petai/patches/medieval-fashion/poultry.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "add",
         "path": "/behaviors",
         "value": [

--- a/resources/assets/petai/patches/medieval-fashion/redmeat.json
+++ b/resources/assets/petai/patches/medieval-fashion/redmeat.json
@@ -1,5 +1,6 @@
 [
     {
+        "side": "server",
         "op": "add",
         "path": "/behaviors",
         "value": [

--- a/src/Entity/AITask/AiTaskFollowMaster.cs
+++ b/src/Entity/AITask/AiTaskFollowMaster.cs
@@ -32,19 +32,19 @@ namespace PetAI
                 return false;
             }
             return entity.GetBehavior<EntityBehaviorReceiveCommand>().complexCommand == commandName
-                && targetEntity.ServerPos.SquareDistanceTo(entity.ServerPos.X, entity.ServerPos.Y, entity.ServerPos.Z) > maxDistance * maxDistance;
+                && targetEntity.Pos.SquareDistanceTo(entity.Pos.X, entity.Pos.Y, entity.Pos.Z) > maxDistance * maxDistance;
         }
 
         public override void OnNoPath(Vec3d target)
         {
-            if (allowTeleport && targetEntity.ServerPos.SquareDistanceTo(entity.ServerPos) > teleportAfterRange * teleportAfterRange)
+            if (allowTeleport && targetEntity.Pos.SquareDistanceTo(entity.Pos) > teleportAfterRange * teleportAfterRange)
             {
                 tryTeleport();
             }
             else
             {
                 stuck = false;
-                pathTraverser.WalkTowards(targetEntity.ServerPos.XYZ, moveSpeed, maxDistance, OnGoalReached, OnStuck);
+                pathTraverser.WalkTowards(targetEntity.Pos.XYZ, moveSpeed, maxDistance, OnGoalReached, OnStuck);
             }
         }
     }

--- a/src/Entity/AITask/AiTaskHappyDance.cs
+++ b/src/Entity/AITask/AiTaskHappyDance.cs
@@ -28,7 +28,7 @@ namespace PetAI
             targetEntity = tameable?.cachedOwner?.Entity;
             return cooldownUntilMs < entity.World.ElapsedMilliseconds
                 && targetEntity != null
-                && targetEntity.ServerPos.SquareDistanceTo(entity.ServerPos) <= 25
+                && targetEntity.Pos.SquareDistanceTo(entity.Pos) <= 25
                 && hasNiceThing(targetEntity);
         }
         public override void StartExecute()
@@ -40,16 +40,16 @@ namespace PetAI
         public override bool ContinueExecute(float dt)
         {
             Vec3f targetVec = new Vec3f(
-                (float)(targetEntity.ServerPos.X - entity.ServerPos.X),
-                (float)(targetEntity.ServerPos.Y - entity.ServerPos.Y),
-                (float)(targetEntity.ServerPos.Z - entity.ServerPos.Z)
+                (float)(targetEntity.Pos.X - entity.Pos.X),
+                (float)(targetEntity.Pos.Y - entity.Pos.Y),
+                (float)(targetEntity.Pos.Z - entity.Pos.Z)
             );
 
             float desiredYaw = (float)Math.Atan2(targetVec.X, targetVec.Z);
 
-            float yawDist = GameMath.AngleRadDistance(entity.ServerPos.Yaw, desiredYaw);
-            entity.ServerPos.Yaw += GameMath.Clamp(yawDist, -250 * dt, 250 * dt);
-            entity.ServerPos.Yaw = entity.ServerPos.Yaw % GameMath.TWOPI;
+            float yawDist = GameMath.AngleRadDistance(entity.Pos.Yaw, desiredYaw);
+            entity.Pos.Yaw += GameMath.Clamp(yawDist, -250 * dt, 250 * dt);
+            entity.Pos.Yaw = entity.Pos.Yaw % GameMath.TWOPI;
 
             return durationUntilMs > entity.World.ElapsedMilliseconds
                 && hasNiceThing(targetEntity)

--- a/src/Entity/AITask/AiTaskPetMeleeAttack.cs
+++ b/src/Entity/AITask/AiTaskPetMeleeAttack.cs
@@ -30,7 +30,7 @@ namespace PetAI
             damage *= PetConfig.Current.Difficulty.petDamageMultiplier;
         }
 
-        public override bool IsTargetableEntity(Entity e, float range, bool ignoreEntityCode = false)
+        public override bool IsTargetableEntity(Entity e, float range)
         {
             var aggressionLevel = entity.GetBehavior<EntityBehaviorReceiveCommand>()?.aggressionLevel;
             if (aggressionLevel == EnumAggressionLevel.PASSIVE) { return false; }
@@ -51,17 +51,17 @@ namespace PetAI
             {
                 if (behaviorGiveCommand?.attacker == e || behaviorGiveCommand?.victim == e)
                 {
-                    return base.IsTargetableEntity(e, range, true);
+                    return base.IsTargetableEntity(e, range);
                 }
             }
             if (attackedByEntity == e)
             {
-                return base.IsTargetableEntity(e, range, true);
+                return base.IsTargetableEntity(e, range);
             }
 
             if (aggressionLevel == EnumAggressionLevel.PROTECTIVE || aggressionLevel == EnumAggressionLevel.NEUTRAL) { return false; }
 
-            return base.IsTargetableEntity(e, range, ignoreEntityCode);
+            return base.IsTargetableEntity(e, range);
         }
     }
 }

--- a/src/Entity/AITask/AiTaskPetSeekEntity.cs
+++ b/src/Entity/AITask/AiTaskPetSeekEntity.cs
@@ -45,30 +45,30 @@ namespace PetAI
                 lastCheck = elapsedMs;
                 if (aggressionLevel == null) { aggressionLevel = EnumAggressionLevel.AGGRESSIVE; }
                 if (aggressionLevel == EnumAggressionLevel.PASSIVE) { return false; }
-                if (!IsTargetableEntity(targetEntity, NowSeekRange, true)) { targetEntity = null; }
+                if (!IsTargetableEntity(targetEntity, NowSeekRange)) { targetEntity = null; }
                 if (targetEntity == null)
                 {
                     if (aggressionLevel != EnumAggressionLevel.NEUTRAL && isCommandable)
                     {
                         var ownerAttackedBy = behaviorGiveCommand?.attacker;
-                        if (IsTargetableEntity(ownerAttackedBy, NowSeekRange, true))
+                        if (IsTargetableEntity(ownerAttackedBy, NowSeekRange))
                         {
                             targetEntity = ownerAttackedBy;
                         }
 
                         var ownerAttacks = behaviorGiveCommand?.victim;
-                        if (IsTargetableEntity(ownerAttacks, NowSeekRange, true))
+                        if (IsTargetableEntity(ownerAttacks, NowSeekRange))
                         {
                             targetEntity = ownerAttacks;
                         }
                     }
-                    if (IsTargetableEntity(attackedByEntity, NowSeekRange, true))
+                    if (IsTargetableEntity(attackedByEntity, NowSeekRange))
                     {
                         targetEntity = attackedByEntity;
                     }
                 }
 
-                if (IsTargetableEntity(targetEntity, NowSeekRange, true))
+                if (IsTargetableEntity(targetEntity, NowSeekRange))
                 {
                     targetPos = targetEntity.ServerPos.XYZ;
                     return true;
@@ -79,7 +79,7 @@ namespace PetAI
                 lastSearch = elapsedMs;
                 targetEntity = partitionUtil.GetNearestInteractableEntity(entity.ServerPos.XYZ, NowSeekRange, e => IsTargetableEntity(e, NowSeekRange));
 
-                if (IsTargetableEntity(targetEntity, NowSeekRange, true))
+                if (IsTargetableEntity(targetEntity, NowSeekRange))
                 {
                     targetPos = targetEntity.ServerPos.XYZ;
                     return true;
@@ -88,7 +88,7 @@ namespace PetAI
             return false;
         }
 
-        public override bool IsTargetableEntity(Entity e, float range, bool ignoreEntityCode = false)
+        public override bool IsTargetableEntity(Entity e, float range)
         {
             if (e == null) { return false; }
             var tameable = entity.GetBehavior<EntityBehaviorTameable>();
@@ -106,7 +106,7 @@ namespace PetAI
             if (e.ServerPos.SquareDistanceTo(entity.ServerPos) > range * range) { return false; }
 
 
-            return base.IsTargetableEntity(e, range, ignoreEntityCode);
+            return base.IsTargetableEntity(e, range);
         }
     }
 }

--- a/src/Entity/AITask/AiTaskPetSeekEntity.cs
+++ b/src/Entity/AITask/AiTaskPetSeekEntity.cs
@@ -70,18 +70,18 @@ namespace PetAI
 
                 if (IsTargetableEntity(targetEntity, NowSeekRange))
                 {
-                    targetPos = targetEntity.ServerPos.XYZ;
+                    targetPos = targetEntity.Pos.XYZ;
                     return true;
                 }
             }
             if (aggressionLevel == EnumAggressionLevel.AGGRESSIVE && lastSearch + 5000 < elapsedMs)
             {
                 lastSearch = elapsedMs;
-                targetEntity = partitionUtil.GetNearestInteractableEntity(entity.ServerPos.XYZ, NowSeekRange, e => IsTargetableEntity(e, NowSeekRange));
+                targetEntity = partitionUtil.GetNearestInteractableEntity(entity.Pos.XYZ, NowSeekRange, e => IsTargetableEntity(e, NowSeekRange));
 
                 if (IsTargetableEntity(targetEntity, NowSeekRange))
                 {
-                    targetPos = targetEntity.ServerPos.XYZ;
+                    targetPos = targetEntity.Pos.XYZ;
                     return true;
                 }
             }
@@ -103,7 +103,7 @@ namespace PetAI
                     return false;
                 }
             }
-            if (e.ServerPos.SquareDistanceTo(entity.ServerPos) > range * range) { return false; }
+            if (e.Pos.SquareDistanceTo(entity.Pos) > range * range) { return false; }
 
 
             return base.IsTargetableEntity(e, range);

--- a/src/Entity/AITask/AiTaskSeekNest.cs
+++ b/src/Entity/AITask/AiTaskSeekNest.cs
@@ -32,11 +32,11 @@ namespace PetAI
                 double hourOfDay = entity.World.Calendar.HourOfDay / entity.World.Calendar.HoursPerDay * 24f + (entity.World.Rand.NextDouble() * 0.3f - 0.15f);
                 if (!Array.Exists(duringDayTimeFrames, frame => frame.Matches(hourOfDay))) return false;
             }
-            if (nest == null || entity.ServerPos.SquareDistanceTo(nest.Position) > 50)
+            if (nest == null || entity.Pos.SquareDistanceTo(nest.Position) > 50)
             {
-                nest = entity.Api.ModLoader.GetModSystem<POIRegistry>().GetNearestPoi(entity.ServerPos.XYZ, range, isValidNonOccupiedNest) as BlockEntityPetNest;
+                nest = entity.Api.ModLoader.GetModSystem<POIRegistry>().GetNearestPoi(entity.Pos.XYZ, range, isValidNonOccupiedNest) as BlockEntityPetNest;
             }
-            return nest != null && entity.ServerPos.SquareDistanceTo(nest.Pos.ToVec3d()) > 2;
+            return nest != null && entity.Pos.SquareDistanceTo(nest.Pos.ToVec3d()) > 2;
         }
 
         private bool isValidNonOccupiedNest(IPointOfInterest poi)

--- a/src/Entity/AITask/AiTaskStay.cs
+++ b/src/Entity/AITask/AiTaskStay.cs
@@ -58,7 +58,7 @@ namespace PetAI
                 return false;
             }
             return entity.GetBehavior<EntityBehaviorReceiveCommand>().complexCommand == commandName &&
-                entity.ServerPos.SquareDistanceTo((float)x, (float)y, (float)z) > maxDistance * maxDistance;
+                entity.Pos.SquareDistanceTo((float)x, (float)y, (float)z) > maxDistance * maxDistance;
         }
         public override void StartExecute()
         {
@@ -78,7 +78,7 @@ namespace PetAI
                 return false;
             }
 
-            if (entity.ServerPos.SquareDistanceTo((double)x, (double)y, (double)z) < maxDistance * maxDistance / 4)
+            if (entity.Pos.SquareDistanceTo((double)x, (double)y, (double)z) < maxDistance * maxDistance / 4)
             {
                 pathTraverser.Stop();
                 return false;

--- a/src/Entity/Behavior/BehaviorReceiveCommand.cs
+++ b/src/Entity/Behavior/BehaviorReceiveCommand.cs
@@ -111,9 +111,9 @@ namespace PetAI
                     complexCommand = command.commandName;
 
                     ITreeAttribute location = new TreeAttribute();
-                    location.SetDouble("x", entity.ServerPos.X);
-                    location.SetDouble("y", entity.ServerPos.Y);
-                    location.SetDouble("z", entity.ServerPos.Z);
+                    location.SetDouble("x", entity.Pos.X);
+                    location.SetDouble("y", entity.Pos.Y);
+                    location.SetDouble("z", entity.Pos.Z);
 
                     entity.WatchedAttributes.SetAttribute("staylocation", location);
                 }

--- a/src/Entity/Behavior/BehaviorTameable.cs
+++ b/src/Entity/Behavior/BehaviorTameable.cs
@@ -287,7 +287,7 @@ namespace PetAI
                 Cuboidf collisionBox = tameType.SpawnCollisionBox;
 
                 // Delay spawning if we're colliding
-                if (entity.World.CollisionTester.IsColliding(entity.World.BlockAccessor, collisionBox, entity.ServerPos.XYZ, false))
+                if (entity.World.CollisionTester.IsColliding(entity.World.BlockAccessor, collisionBox, entity.Pos.XYZ, false))
                 {
                     callbackId = entity.World.RegisterCallback(spawnTameVariant, 1000);
                     return;
@@ -295,8 +295,8 @@ namespace PetAI
 
                 tameEntity = entity.World.ClassRegistry.CreateEntity(tameType);
 
-                tameEntity.ServerPos.SetFrom(entity.ServerPos);
-                tameEntity.Pos.SetFrom(tameEntity.ServerPos);
+                tameEntity.Pos.SetFrom(entity.Pos);
+                tameEntity.Pos.SetFrom(tameEntity.Pos);
 
                 entity.Die(EnumDespawnReason.Expire, null);
                 entity.World.SpawnEntity(tameEntity);
@@ -487,7 +487,7 @@ namespace PetAI
                         Color = 9044739,
                         Icon = "gravestone",
                         Pinned = true,
-                        Position = entity.ServerPos.XYZ,
+                        Position = entity.Pos.XYZ,
                         OwningPlayerUid = ownerId,
                         Title = Lang.Get("petai:message-pet-dead", entity.GetBehavior<EntityBehaviorNameTag>()?.DisplayName),
                     },

--- a/src/Item/ItemPetCarrier.cs
+++ b/src/Item/ItemPetCarrier.cs
@@ -32,7 +32,7 @@ namespace PetAI
             else if (byEntity.Controls.Sneak && Variant["type"] != "empty")
             {
                 pet = PetUtil.EntityFromTree(slot.Itemstack.Attributes, byEntity.World);
-                pet.ServerPos.SetPos(byEntity.ServerPos);
+                pet.Pos.SetPos(byEntity.Pos);
                 byEntity.World.SpawnEntity(pet);
                 slot.Itemstack = new ItemStack(byEntity.World.GetItem(slot.Itemstack.Item.CodeWithVariant("type", "empty")).Id,
                                         EnumItemClass.Item,

--- a/src/Item/ItemPetWhistle.cs
+++ b/src/Item/ItemPetWhistle.cs
@@ -25,7 +25,7 @@ namespace PetAI
                 byEntity.AnimManager?.StartAnimation("eat");
                 if (byEntity.Api?.Side == EnumAppSide.Server)
                 {
-                    byEntity.World?.PlaySoundAt(new AssetLocation("petai:sounds/whistling.ogg"), byEntity.ServerPos.X, byEntity.ServerPos.Y, byEntity.ServerPos.Z);
+                    byEntity.World?.PlaySoundAt(new AssetLocation("petai:sounds/whistling.ogg"), byEntity.Pos.X, byEntity.Pos.Y, byEntity.Pos.Z);
                 }
                 notifyNearbyPets(byEntity);
             }
@@ -39,7 +39,7 @@ namespace PetAI
             var command = giveBehavior.activeCommand;
             if (command == null) return;
 
-            var petArray = byEntity.World.GetEntitiesAround(byEntity.ServerPos.XYZ, 15, 5, entity => entity.HasBehavior<EntityBehaviorReceiveCommand>());
+            var petArray = byEntity.World.GetEntitiesAround(byEntity.Pos.XYZ, 15, 5, entity => entity.HasBehavior<EntityBehaviorReceiveCommand>());
 
             var player = byEntity as EntityPlayer;
             Entity target = null;
@@ -88,7 +88,7 @@ namespace PetAI
                     attackTask.ClearAttacker();
                 }
 
-                
+
                 foreach (var task in taskManager.AllTasks)
                 {
                     (task as AiTaskBaseTargetable)?.ClearAttacker();

--- a/src/Item/ItemPetWhistle.cs
+++ b/src/Item/ItemPetWhistle.cs
@@ -48,7 +48,7 @@ namespace PetAI
                 EntitySelection entitySel = null;
                 BlockSelection blockSel = null;
                 Vec3d pos = player.Pos.XYZ.Add(player.LocalEyePos);
-                player.World.RayTraceForSelection(pos, player.SidedPos.Pitch, player.SidedPos.Yaw, 50, ref blockSel, ref entitySel);
+                player.World.RayTraceForSelection(pos, player.Pos.Pitch, player.Pos.Yaw, 50, ref blockSel, ref entitySel);
                 giveBehavior.victim = entitySel?.Entity;
                 target = entitySel?.Entity;
             }


### PR DESCRIPTION
Part 1 of "bring the pet suite mods to 1.22.0". Tested in a creative world in conjunction with https://github.com/G3rste/wolftaming/pull/27 .

- VS now uses .NET 10 instead of 8
- `AiTaskBaseTargetable.IsTargetableEntity()` no longer has its third `ignoreEntityCode` parameter. I *think* we can just get rid of it, but I am a bit worried that in two cases we used `true` literal and in one we passed our own `ignore` value to the base implementation... I also could not find anything about this API change in either discord or VS website.
- `ServerPos` and `SidedPos` now reference regular `Pos`, and using them emits a lot of warnings during compilation, so I just massreplaced everything anyway.
- While probably not directly 1.22-related, there was a bunch of
```
[VerboseDebug] Patch 0 in petai:patches/entities/player.json: File game:entities/humanoid/player.json not found. Hint: This asset is usually only loaded Server side
```
in logs, so I sprinkled the patches with some `side:server` to get these out. Can be re-done in a separate PR for clarity.

