### PR TITLE
Fix pet profile dialog reseting multiplyAllowed value

### DIFF
--- a/PetAI/src/Gui/PetProfile.cs
+++ b/PetAI/src/Gui/PetProfile.cs
@@ -56,6 +56,7 @@ namespace PetAI
             if (targetEntity?.HasBehavior<EntityBehaviorMultiply>() == true)
             {
                 var multiply = targetEntity.GetBehavior<EntityBehaviorTameable>().MultiplyAllowed;
+                multiplyAllowed = multiply;
                 SingleComposer.AddStaticText(Lang.Get("petai:gui-profile-multiply"), CairoFont.WhiteSmallishText(), ElementBounds.Fixed(0, currentY, 200, 20));
                 SingleComposer.AddSwitch(value => multiplyAllowed = value, ElementBounds.Fixed(150, currentY, 200, 20), "multiplyAllowed");
                 SingleComposer.GetSwitch("multiplyAllowed").SetValue(multiply);


### PR DESCRIPTION
Addresses the [comment](https://github.com/G3rste/petai/issues/76#issuecomment-4289276496) I left in #76.

I rebuilt PetAI locally with this change (though admittedly back when ba43ed7e96a28e92fcc01dfce8c6285683b4561a was the latest commit) and we've been running it on our local 1.21.6 server for the last few days – seems alright so far.