### PR TITLE
Fixed mounts returning to staylocation after being ridden while stay command is active

### DIFF
--- a/PetAI/src/Entity/AITask/AiTaskStay.cs
+++ b/PetAI/src/Entity/AITask/AiTaskStay.cs
@@ -37,8 +37,20 @@ namespace PetAI
 
         public override bool ShouldExecute()
         {
-            if (entity?.GetBehavior<EntityBehaviorReceiveCommand>()?.ComplexCommand != commandName
-                || entity?.GetBehavior<EntityBehaviorRideable>()?.AnyMounted() == true)
+        if (entity?.GetBehavior<EntityBehaviorRideable>()?.AnyMounted() == true)
+            {
+                x = null;
+                y = null;
+                z = null;
+                ITreeAttribute stayloc = entity?.WatchedAttributes?.GetTreeAttribute("staylocation");
+                if (stayloc != null)
+                {
+                    entity?.WatchedAttributes?.RemoveAttribute("staylocation");
+                }
+                return false;
+            }
+            
+            if (entity?.GetBehavior<EntityBehaviorReceiveCommand>()?.ComplexCommand != commandName)
             {
                 x = null;
                 y = null;
@@ -73,6 +85,8 @@ namespace PetAI
             {
                 return false;
             }
+
+            
 
             if (entity.Pos.SquareDistanceTo((double)x, (double)y, (double)z) < maxDistance * maxDistance / 4)
             {


### PR DESCRIPTION
Added a check in the stay ai task that clears the stay location when an entity is mounted/ridden. This prevents the entity from trying to return to the stay location if it was mounted and ridden while the stay command was active. Tested, seems to work fine